### PR TITLE
[Agenda] sepolia - 172 - Test: Adjust PowerTON Seigniorage Rate to 40%

### DIFF
--- a/data/agendas/sepolia/agenda-172.json
+++ b/data/agendas/sepolia/agenda-172.json
@@ -1,0 +1,60 @@
+{
+  "id": 172,
+  "title": "Test: Adjust PowerTON Seigniorage Rate to 40%",
+  "description": "https://github.com/tokamak-network/TOIPs/blob/main/test-powerTON-seig-rate-adjustment.md",
+  "network": "sepolia",
+  "transaction": "0x466c1116b8aed93b55f5568da6f906c7db788ca19cca5357d4914e6371e071ad",
+  "creator": {
+    "address": "0xB68AA9E398c054da7EBAaA446292f611CA0CD52B",
+    "signature": "0x1b12a44d77ffe57772494d35b79831f5a34da30db6944dacc741770a7607b0587886236f4789c4ad401c0999d02fe2c934b07f2f17cd3c426e520f17270812511b"
+  },
+  "actions": [
+    {
+      "title": "setDaoSeigRate(uint256)",
+      "contractAddress": "0x2320542ae933FbAdf8f5B97cA348c7CeDA90fAd7",
+      "method": "setDaoSeigRate(uint256)",
+      "calldata": "0x03e1cc270000000000000000000000000000000000000000014adf4b7320334b90000000",
+      "abi": [
+        {
+          "inputs": [
+            {
+              "internalType": "uint256",
+              "name": "daoSeigRate_",
+              "type": "uint256"
+            }
+          ],
+          "name": "setDaoSeigRate",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        }
+      ],
+      "sendEth": false
+    },
+    {
+      "title": "setPowerTONSeigRate(uint256)",
+      "contractAddress": "0x2320542ae933FbAdf8f5B97cA348c7CeDA90fAd7",
+      "method": "setPowerTONSeigRate(uint256)",
+      "calldata": "0x9c877e4700000000000000000000000000000000000000000052b7d2dcc80cd2e4000000",
+      "abi": [
+        {
+          "inputs": [
+            {
+              "internalType": "uint256",
+              "name": "powerTONSeigRate_",
+              "type": "uint256"
+            }
+          ],
+          "name": "setPowerTONSeigRate",
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "type": "function"
+        }
+      ],
+      "sendEth": false
+    }
+  ],
+  "createdAt": "2025-07-29T20:00:13.00Z",
+  "snapshotUrl": "https://snapshot.org/#/tokamak-dao.eth/proposal/0xabcdef1234567890",
+  "discourseUrl": ""
+}


### PR DESCRIPTION
## Agenda Metadata Submission
- Network: sepolia
- Agenda ID: 172
- Title: Test: Adjust PowerTON Seigniorage Rate to 40%
- Transaction Hash: 0x466c1116b8aed93b55f5568da6f906c7db788ca19cca5357d4914e6371e071ad
- Creator Address: 0xB68AA9E398c054da7EBAaA446292f611CA0CD52B
- Signature: 0x1b12a44d77ffe57772494d35b79831f5a34da30db6944dacc741770a7607b0587886236f4789c4ad401c0999d02fe2c934b07f2f17cd3c426e520f17270812511b

## Description
Agenda submission for sepolia network - Test: Adjust PowerTON Seigniorage Rate to 40%

## Type of change
- [x] New agenda

## Checklist
- [x] My PR title follows the format: `[Agenda] <network> - <agenda_id> - <agenda_title>`
- [x] I have added only one agenda file
- [x] I have verified the agenda metadata
- [x] I have checked the agenda ID matches the PR title
- [x] I have verified the network (mainnet/sepolia) matches the PR title